### PR TITLE
Improved PersistentId support to not depend on hash of email

### DIFF
--- a/djangosaml2idp/migrations/0001_initial.py
+++ b/djangosaml2idp/migrations/0001_initial.py
@@ -42,4 +42,18 @@ class Migration(migrations.Migration):
             model_name='serviceprovider',
             index=models.Index(fields=['entity_id'], name='djangosaml2_entity__5fb9e3_idx'),
         ),
+        migrations.CreateModel(
+            name='PersistentId',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('persistent_id', models.CharField(max_length=256, verbose_name='User Persistent Id for this SP')),
+                ('created', models.DateTimeField(default=django.utils.timezone.now)),
+                ('sp', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='djangosaml2idp.ServiceProvider')),
+                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+            ],
+            options={
+                'verbose_name': 'Persistent Id',
+                'unique_together': {('sp', 'persistent_id'), ('sp', 'user')},
+            },
+        ),
     ]

--- a/djangosaml2idp/models.py
+++ b/djangosaml2idp/models.py
@@ -185,3 +185,14 @@ class ServiceProvider(models.Model):
             config_as_str = f'Could not render config: {e}'
         # Some ugly replacements to have the json decently printed in the admin
         return mark_safe(config_as_str.replace("\n", "<br>").replace("    ", "&nbsp;&nbsp;&nbsp;&nbsp;"))
+
+
+class PersistentId(models.Model):
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    sp = models.ForeignKey(ServiceProvider, on_delete=models.CASCADE)
+    persistent_id = models.CharField("User Persistent Id for this SP", max_length=256)
+    created = models.DateTimeField(default=now)
+
+    class Meta:
+        unique_together = [["sp", "persistent_id"], ["sp", "user"]]
+        verbose_name = 'Persistent Id'


### PR DESCRIPTION
A user email, service provider url, or identity provider url might change over time. In the previous system, which relies on all these things, this would change the PersistendId, leading to possible account loss on the client side. By using a random uuid stored in the database, this risk is alleviated.